### PR TITLE
Customize nccu skin

### DIFF
--- a/app/views/catalog/_home_text.html.erb
+++ b/app/views/catalog/_home_text.html.erb
@@ -1,0 +1,9 @@
+<div class="page-header">
+  <h1 class="main-title"><%= t('blacklight.home.welcome') %></h1>
+  <p class="tagline"><%= t('blacklight.home.blurb') %></h4>
+</div>
+
+<ul class="underlined-links home-welcome-links">
+  <li><%= link_to t('blacklight.help.ask_a_librarian'), TrlnArgon::Engine.configuration.contact_url, target: "_blank" %> <%= t('blacklight.help.for_answers') %></li>
+  <li><%= t("blacklight.help.worldcat_link_html") %></li>
+</ul>

--- a/app/views/catalog/_local_filter.html.erb
+++ b/app/views/catalog/_local_filter.html.erb
@@ -1,0 +1,21 @@
+<% query_state = query_state_from_search_state(search_state) %>
+<% query_state.delete('page') %>
+
+
+<div class="toggle toggle-trln">
+
+  <%= button_tag( type: "button",
+                  id: trln_button_id,
+                  class: "btn btn-md #{trln_search_button_class}",
+                  title: "#{t("trln_argon.local_filter.search_verb")} #{t("trln_argon.local_filter.searching_trln")}",
+                  onclick: "window.location='#{search_trln_path(query_state)}'"
+                ) do %>
+    <span class="sr-only">icon</span><span class="icon-wrapper"></span>
+  <% end %>
+
+  <%= label_tag( trln_button_id,
+                 "#{t("trln_argon.local_filter.searching_trln")}",
+                 class: "#{trln_search_button_label_class}",
+                 data: { count_only_path: trln_argon.trln_count_only_path(query_state) }) %>
+
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,14 @@
 en:
   blacklight:
     home:
-      welcome: "Central University Libraries Catalog"
-      blurb: "Find books, ebooks, journals, movies and music, government documents, and more"
+      welcome: "Search TRLN"
+      blurb: "Find books, ebooks, journals, movies and music, government documents, and more from all TRLN libraries"
+    help:
+      ask_a_librarian: "Ask a Librarian"
+      for_answers: "to get answers quickly"
+      worldcat_link_html: "Use <a href='https://northcarolinacentuniversity.worldcat.org/' target='_blank'>WorldCat</a> to search holdings from UNC System Libraries & Beyond"
+
+trln_argon:
 
   trln_argon:
     links:

--- a/lib/nccu_blacklight/version.rb
+++ b/lib/nccu_blacklight/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module DulArgonSkin
+  VERSION = '0.0.1'
+end


### PR DESCRIPTION
- remove ability to filter to only NCCU results
- the home landing page is referred to as Search TRLN
- Include two links on a landing page: Worldcat and 'Ask a librarian'